### PR TITLE
Used dynamic viewport and scissor in renderpass

### DIFF
--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -189,43 +189,16 @@ make_graphics_pipeline(const GraphicsPipelineInBundle &specification) {
       .pName = "main"};
 
   // Viewport and Scissor
-  // Dynamic state in command buffer
-  /*   std::vector<vk::DynamicState> dynamic_states =
-    {vk::DynamicState::eViewport, vk::DynamicState::eScissor};
-    vk::PipelineDynamicStateCreateInfo dynamic_state_info{
-        .dynamicStateCount = static_cast<uint32_t>(dynamic_states.size()),
-        .pDynamicStates = dynamic_states.data()};
+  // Dynamic states to be modified in command buffer - at drawing time
+  std::vector<vk::DynamicState> dynamic_states = {vk::DynamicState::eViewport,
+                                                  vk::DynamicState::eScissor};
+  vk::PipelineDynamicStateCreateInfo dynamic_state_info{
+      .dynamicStateCount = static_cast<uint32_t>(dynamic_states.size()),
+      .pDynamicStates = dynamic_states.data()};
 
-    // Specify their count at pipeline  creation time
-    // The actual viewport and scissor rectangle will be later set up at
-    drawing
-    // time
-    vk::PipelineViewportStateCreateInfo viewport_state{.viewportCount = 1,
-                                                       .scissorCount = 1};
-   */
-  // Viewport and Scissor
-  vk::Viewport viewport = {
-      .x = 0.0f,
-      .y = 0.0f,
-      .width = (float)specification.swapchain_extent.width,
-      .height = (float)specification.swapchain_extent.height,
-      .minDepth = 0.0f,
-      .maxDepth = 1.0f,
-  };
-
-  vk::Rect2D scissor = {
-      .offset{
-          .x = 0,
-          .y = 0,
-      },
-      .extent = specification.swapchain_extent,
-  };
-  vk::PipelineViewportStateCreateInfo viewport_state = {
-      .viewportCount = 1,
-      .pViewports = &viewport,
-      .scissorCount = 1,
-      .pScissors = &scissor,
-  };
+  vk::PipelineViewportStateCreateInfo viewport_state{.viewportCount = 1,
+                                                     .scissorCount = 1};
+  pipeline_info.pDynamicState = &dynamic_state_info;
   pipeline_info.pViewportState = &viewport_state;
 
   // Rasterizer

--- a/src/vulkan_ice.cpp
+++ b/src/vulkan_ice.cpp
@@ -783,6 +783,18 @@ void VulkanIce::record_sky_draw_commands(vk::CommandBuffer command_buffer,
   command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics,
                               pipeline[PipelineType::SKY]);
 
+  // dynamic viewport and scissor specification
+  vk::Viewport viewport{.x = 0.0f,
+                        .y = 0.0f,
+                        .width = static_cast<float>(swapchain_extent.width),
+                        .height = static_cast<float>(swapchain_extent.height),
+                        .minDepth = 0.0f,
+                        .maxDepth = 1.0f};
+  command_buffer.setViewport(0, 1, &viewport);
+
+  vk::Rect2D scissor{.offset = {0, 0}, .extent = swapchain_extent};
+  command_buffer.setScissor(0, 1, &scissor);
+
   command_buffer.bindDescriptorSets(
       vk::PipelineBindPoint::eGraphics, pipeline_layout[PipelineType::SKY], 0,
       swapchain_frames[image_index].descriptor_sets[PipelineType::SKY],
@@ -821,6 +833,17 @@ void VulkanIce::record_scene_draw_commands(vk::CommandBuffer command_buffer,
 
   command_buffer.bindPipeline(vk::PipelineBindPoint::eGraphics,
                               pipeline[PipelineType::STANDARD]);
+
+  vk::Viewport viewport{.x = 0.0f,
+                        .y = 0.0f,
+                        .width = static_cast<float>(swapchain_extent.width),
+                        .height = static_cast<float>(swapchain_extent.height),
+                        .minDepth = 0.0f,
+                        .maxDepth = 1.0f};
+  command_buffer.setViewport(0, 1, &viewport);
+
+  vk::Rect2D scissor{.offset = {0, 0}, .extent = swapchain_extent};
+  command_buffer.setScissor(0, 1, &scissor);
 
   command_buffer.bindDescriptorSets(
       vk::PipelineBindPoint::eGraphics, pipeline_layout[PipelineType::STANDARD],


### PR DESCRIPTION
Edits:
pipeline.hpp:
* make_graphics_pipeline: defined a dynamic state containing viewport and scissor to be used in the pipeline, but bound later.

vulkan_ice:
 * record_xxxx_draw_commands: For both sky and scene render passes, a viewport and scissor was created and set in the  command buffer after binding the correct pipeline.