### PR TITLE
Multisampling support

### DIFF
--- a/src/framebuffer.hpp
+++ b/src/framebuffer.hpp
@@ -22,10 +22,9 @@ struct FramebufferInput {
 inline void make_framebuffers(const FramebufferInput &input_bundle,
                               std::vector<SwapChainFrame> &out_frames) {
   for (int i = 0; i < out_frames.size(); ++i) {
-    std::vector<vk::ImageView> attachments = {
-        out_frames[i].image_view,
-    };
+    std::vector<vk::ImageView> attachments = {out_frames[i].color_buffer_view};
 
+    // Sky Pipeline
     vk::FramebufferCreateInfo framebuffer_info{
         .renderPass = input_bundle.renderpass.at(PipelineType::SKY),
         .attachmentCount = static_cast<std::uint32_t>(attachments.size()),
@@ -43,7 +42,9 @@ inline void make_framebuffers(const FramebufferInput &input_bundle,
                 << std::endl;
     }
 
-    attachments.push_back(out_frames[i].depth_buffer_view);
+    // Standard Pipeline
+    attachments = {out_frames[i].color_buffer_view,
+                   out_frames[i].depth_buffer_view, out_frames[i].image_view};
     framebuffer_info.renderPass =
         input_bundle.renderpass.at(PipelineType::STANDARD);
     framebuffer_info.attachmentCount =

--- a/src/images/ice_image.cpp
+++ b/src/images/ice_image.cpp
@@ -18,7 +18,7 @@ vk::Image make_image(const ImageCreationInput &input) {
       .mipLevels = input.mip_levels,
       .arrayLayers = input.array_count,
 
-      .samples = vk::SampleCountFlagBits::e1,
+      .samples = input.msaa_samples,
       .tiling = input.tiling,
       .usage = input.usage,
 

--- a/src/images/ice_image.hpp
+++ b/src/images/ice_image.hpp
@@ -29,6 +29,7 @@ struct ImageCreationInput {
   std::uint32_t array_count{1};
   vk::ImageCreateFlags create_flags;
   std::uint32_t mip_levels{1};
+  vk::SampleCountFlagBits msaa_samples{vk::SampleCountFlagBits::e1};
 };
 
 // input needed for image layout transitions jobs

--- a/src/images/ice_texture.cpp
+++ b/src/images/ice_texture.cpp
@@ -3,7 +3,6 @@
 #include "ice_texture.hpp"
 #include "../data_buffers.hpp"
 #include "../descriptors.hpp"
-#include "images/ice_image.hpp"
 
 namespace ice_image {
 
@@ -150,13 +149,14 @@ void Texture::populate() {
   memcpy(write_location, pixels, input.size);
   logical_device.unmapMemory(staging_buffer.buffer_memory);
 
-  // then transfer it to image memory
+  // transition layout
   ImageLayoutTransitionJob transition_job{
       .command_buffer = command_buffer,
       .queue = queue,
       .image = image,
       .old_layout = vk::ImageLayout::eUndefined,
-      .new_layout = vk::ImageLayout::eTransferDstOptimal,
+      .new_layout =
+          vk::ImageLayout::eTransferDstOptimal, /* Because it will Blitted on*/
       .mip_levels = mip_levels};
 
   transition_image_layout(transition_job);

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -16,14 +16,12 @@ struct GraphicsPipelineInBundle {
   std::string vertex_filepath;
   std::string fragment_filepath;
   vk::Extent2D swapchain_extent;
-  std::vector<vk::Format> swapchain_image_format;
+  vk::Format swapchain_image_format;
   std::optional<vk::Format> swapchain_depth_format;
   std::vector<vk::DescriptorSetLayout> descriptor_set_layouts;
-  /*  bool should_overwrite; */
   vk::AttachmentLoadOp load_op{vk::AttachmentLoadOp::eClear};
-  /* vk::AttachmentStoreOp store_op {vk::AttachmentStoreOp::eStore} */;
   vk::ImageLayout initial_layout{vk::ImageLayout::eUndefined};
-  /* vk::ImageLayout final_layout{vk::ImageLayout::ePresentSrcKHR} */;
+  vk::SampleCountFlagBits msaa_samples{vk::SampleCountFlagBits::e1};
 };
 
 struct GraphicsPipelineOutBundle {
@@ -103,81 +101,167 @@ inline vk::RenderPass make_imgui_renderpass(
   }
 }
 
-inline vk::RenderPass
-make_renderpass(const vk::Device &device,
-                const std::vector<vk::Format> &swapchain_image_format,
-                const std::optional<vk::Format> &swapchain_depth_format,   vk::AttachmentLoadOp load_op = vk::AttachmentLoadOp::eDontCare,
-  /* vk::AttachmentStoreOp store_op = vk::AttachmentStoreOp::eDontCare, */
-  vk::ImageLayout initial_layout = vk::ImageLayout::eUndefined/* ,
-  vk::ImageLayout final_layout = vk::ImageLayout::ePresentSrcKHR */) {
+inline vk::RenderPass make_scene_renderpass(
+    const vk::Device &device, const vk::Format swapchain_image_format,
+    const vk::Format swapchain_depth_format, vk::AttachmentLoadOp load_op,
+    vk::ImageLayout initial_layout, vk::SampleCountFlagBits msaa_samples) {
 #ifndef NDEBUG
-  std::cout << "Making Renderpass" << std::endl;
+  std::cout << "\nMaking Scene Renderpass" << std::endl;
+#endif
+  std::vector<vk::AttachmentDescription> attachments;
+  std::vector<vk::AttachmentReference> color_attachment_refs;
+
+  vk::AttachmentDescription color_attachment = {
+      .format = swapchain_image_format,
+      .samples = msaa_samples,
+      .loadOp = load_op,
+      .storeOp = vk::AttachmentStoreOp::eDontCare,
+      .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
+      .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
+      .initialLayout = initial_layout,
+      .finalLayout = vk::ImageLayout::eColorAttachmentOptimal};
+  attachments.push_back(color_attachment);
+  color_attachment_refs.push_back(
+      {0, vk::ImageLayout::eColorAttachmentOptimal});
+
+  vk::AttachmentDescription depth_attachment = {
+      .format = swapchain_depth_format,
+      .samples = msaa_samples,
+      .loadOp = vk::AttachmentLoadOp::eClear,
+      .storeOp = vk::AttachmentStoreOp::eDontCare,
+      .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
+      .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
+      .initialLayout = vk::ImageLayout::eUndefined,
+      .finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal};
+  attachments.push_back(depth_attachment);
+  vk::AttachmentReference depth_attachment_ref = {
+      .attachment = 1,
+      .layout = vk::ImageLayout::eDepthStencilAttachmentOptimal};
+
+  vk::AttachmentDescription resolve_attachment = {
+      .format = swapchain_image_format,
+      .samples = vk::SampleCountFlagBits::e1,
+      .loadOp = vk::AttachmentLoadOp::eDontCare,
+      .storeOp = vk::AttachmentStoreOp::eStore,
+      .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
+      .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
+      .initialLayout = vk::ImageLayout::eUndefined,
+      .finalLayout = vk::ImageLayout::eColorAttachmentOptimal};
+  attachments.push_back(resolve_attachment);
+  vk::AttachmentReference resolve_attachment_ref = {
+      2, vk::ImageLayout::eColorAttachmentOptimal};
+
+#ifndef NDEBUG
+  std::cout << "Attachments:\n";
+  for (int index{0}; const auto &attachment : attachments) {
+    std::cout << std::format("Attachment {}  \n", index);
+
+    std::cout << std::format(
+        "Image format : {}\n"
+        "Initial layout : {}\n"
+        "Final   layout : {}\n"
+        "loadOp         : {}\n"
+        "StoreOp        : {}\n"
+        "MSAA samples   : {}\n",
+        vk::to_string(attachment.format),
+        vk::to_string(attachment.initialLayout),
+        vk::to_string(attachment.finalLayout), vk::to_string(attachment.loadOp),
+        vk::to_string(attachment.storeOp), vk::to_string(attachment.samples));
+    ++index;
+  }
 #endif
 
-  // To collate attachments
-  std::vector<vk::AttachmentDescription> attachments;
-
-  // Color attachments
-  attachments.reserve(swapchain_image_format.size());
-  std::vector<vk::AttachmentReference> color_attachment_refs;
-  color_attachment_refs.reserve(swapchain_image_format.size());
-
-  bool depth_present = swapchain_depth_format.has_value();
-
-  std::uint32_t attachment_index{0};
-  for (vk::Format color_image_format : swapchain_image_format) {
-    vk::AttachmentDescription color_attachment = {
-        .format = color_image_format,
-        .samples = vk::SampleCountFlagBits::e1,
-        .loadOp = load_op,
-        .storeOp = vk::AttachmentStoreOp::eStore,
-        .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
-        .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
-        .initialLayout = initial_layout,
-        .finalLayout = vk::ImageLayout::ePresentSrcKHR};
-
-    if (depth_present) { // Standard pipeline
-      color_attachment.finalLayout = vk::ImageLayout::eColorAttachmentOptimal;
-    }
-
-    attachments.emplace_back(color_attachment);
-
-    vk::AttachmentReference color_attachment_ref = {
-        .attachment = attachment_index,
-        .layout = vk::ImageLayout::eColorAttachmentOptimal};
-    color_attachment_refs.emplace_back(color_attachment_ref);
-
-    ++attachment_index;
-  }
-
-  // Depth Attachment
-  vk::AttachmentReference depth_attachment_ref{};
-  if (depth_present) {
-    vk ::AttachmentDescription depth_attachment{
-        .format = swapchain_depth_format.value(),
-        .samples = vk::SampleCountFlagBits::e1,
-        .loadOp = vk::AttachmentLoadOp::eClear,
-        .storeOp = vk::AttachmentStoreOp::eDontCare,
-        .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
-        .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
-        .initialLayout = vk::ImageLayout::eUndefined,
-        .finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal};
-
-    attachments.emplace_back(depth_attachment);
-
-    depth_attachment_ref = {
-        .attachment = attachment_index,
-        .layout = vk::ImageLayout::eDepthStencilAttachmentOptimal};
-  }
-
-  // pass attachment refs
   vk::SubpassDescription subpass = {
       .pipelineBindPoint = vk::PipelineBindPoint::eGraphics,
       .colorAttachmentCount =
           static_cast<std::uint32_t>(color_attachment_refs.size()),
       .pColorAttachments = color_attachment_refs.data(),
-      .pDepthStencilAttachment =
-          depth_present ? &depth_attachment_ref : nullptr};
+      .pResolveAttachments = &resolve_attachment_ref,
+      .pDepthStencilAttachment = &depth_attachment_ref};
+
+  vk::SubpassDependency dependency = {
+      .srcSubpass = vk::SubpassExternal,
+      .dstSubpass = 0,
+      .srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      .dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
+      .dstAccessMask = vk::AccessFlagBits::eColorAttachmentRead};
+
+#ifndef NDEBUG
+  std::cout << std::format("Renderpass Details\n"
+                           "Attachments      : {}\n"
+                           "Attachments Refs : {}\n\n",
+                           attachments.size(), color_attachment_refs.size());
+
+#endif
+
+  vk::RenderPassCreateInfo renderpass_info{
+      .attachmentCount = static_cast<std::uint32_t>(attachments.size()),
+      .pAttachments = attachments.data(),
+      .subpassCount = 1,
+      .pSubpasses = &subpass,
+      .dependencyCount = 1,
+      .pDependencies = &dependency};
+
+  return device.createRenderPass(renderpass_info);
+}
+
+inline vk::RenderPass make_sky_renderpass(
+    const vk::Device &device, const vk::Format swapchain_image_format,
+    vk::AttachmentLoadOp load_op = vk::AttachmentLoadOp::eDontCare,
+    vk::ImageLayout initial_layout = vk::ImageLayout::eUndefined,
+    vk::SampleCountFlagBits msaa_samples = vk::SampleCountFlagBits::e1) {
+#ifndef NDEBUG
+  std::cout << "\nMaking Sky Renderpass" << std::endl;
+#endif
+
+  std::vector<vk::AttachmentDescription> attachments;
+  std::vector<vk::AttachmentReference> color_attachment_refs;
+
+  vk::AttachmentDescription color_attachment = {
+      .format = swapchain_image_format,
+      .samples = msaa_samples,
+      .loadOp = load_op,
+      .storeOp = vk::AttachmentStoreOp::eStore,
+      .stencilLoadOp = vk::AttachmentLoadOp::eDontCare,
+      .stencilStoreOp = vk::AttachmentStoreOp::eDontCare,
+      .initialLayout = initial_layout,
+      .finalLayout = vk::ImageLayout::eColorAttachmentOptimal};
+
+#ifndef NDEBUG
+  std::cout << "Attachment 0  : Color Attachment:\n";
+
+  std::cout << std::format("Initial layout : {}\n"
+                           "Final   layout : {}\n"
+                           "loadOp         : {}\n"
+                           "StoreOp        : {}\n"
+                           "MSAA samples   : {}\n",
+                           vk::to_string(color_attachment.initialLayout),
+                           vk::to_string(color_attachment.finalLayout),
+                           vk::to_string(color_attachment.loadOp),
+                           vk::to_string(color_attachment.storeOp),
+                           vk::to_string(color_attachment.samples));
+#endif
+
+  attachments.push_back(color_attachment);
+  vk::AttachmentReference color_attachment_ref = {
+      .attachment = 0, .layout = vk::ImageLayout::eColorAttachmentOptimal};
+
+  color_attachment_refs.push_back(color_attachment_ref);
+
+  // pass attachment refs
+  vk::SubpassDescription subpass = {
+      .pipelineBindPoint = vk::PipelineBindPoint::eGraphics,
+      .colorAttachmentCount = static_cast<std::uint32_t>(attachments.size()),
+      .pColorAttachments = &color_attachment_ref,
+  };
+
+#ifndef NDEBUG
+  std::cout << std::format("Renderpass Details\n"
+                           "Attachments      : {}\n"
+                           "Attachments Refs : {}\n\n",
+                           attachments.size(), color_attachment_refs.size());
+#endif
 
   vk::RenderPassCreateInfo renderpass_info{
       .attachmentCount = static_cast<std::uint32_t>(attachments.size()),
@@ -284,8 +368,11 @@ make_graphics_pipeline(const GraphicsPipelineInBundle &specification) {
 
   // multisampling
   vk::PipelineMultisampleStateCreateInfo multisamping_info{
-      .rasterizationSamples = vk::SampleCountFlagBits::e1,
-      .sampleShadingEnable = vk::False,
+      .rasterizationSamples = specification.msaa_samples,
+      .sampleShadingEnable =
+          vk::True, // improves image quality, performance cost
+      .minSampleShading =
+          .2f // Min fraction for sample shading: closer to 1 is smoother
   };
   pipeline_info.pMultisampleState = &multisamping_info;
 
@@ -298,7 +385,7 @@ make_graphics_pipeline(const GraphicsPipelineInBundle &specification) {
   };
   vk::PipelineColorBlendStateCreateInfo color_blending_info = {
       .flags = vk::PipelineColorBlendStateCreateFlags(),
-      .logicOpEnable = VK_FALSE,
+      .logicOpEnable = vk::False,
       .logicOp = vk::LogicOp::eCopy,
       .attachmentCount = 1,
       .pAttachments = &color_blend_attachment,
@@ -321,20 +408,24 @@ make_graphics_pipeline(const GraphicsPipelineInBundle &specification) {
       specification.device, specification.descriptor_set_layouts);
   pipeline_info.layout = pipeline_layout;
 
-  //  Renderpass
-  vk::RenderPass renderpass = make_renderpass(
-      specification.device, specification.swapchain_image_format,
-      specification.swapchain_depth_format, specification.load_op,
-      /* specification.store_op, */ specification.initial_layout/* ,
-      specification.final_layout */);
+  // choose which renderpass to make
+  vk::RenderPass renderpass =
+      specification.swapchain_depth_format.has_value()
+          ? make_scene_renderpass(
+                specification.device, specification.swapchain_image_format,
+                specification.swapchain_depth_format.value(),
+                specification.load_op, specification.initial_layout,
+                specification.msaa_samples)
+          : make_sky_renderpass(
+                specification.device, specification.swapchain_image_format,
+                specification.load_op, specification.initial_layout,
+                specification.msaa_samples);
+
   pipeline_info.renderPass = renderpass;
   pipeline_info.subpass = 0;
 
-  // Good for derivative pipelines
-  pipeline_info.basePipelineHandle = nullptr;
+  pipeline_info.basePipelineHandle = nullptr; // no derivatives
 
-  // Create pipeline
-  // Graphics pipeline
   vk::Pipeline graphics_pipeline =
       specification.device.createGraphicsPipeline(nullptr, pipeline_info).value;
   if (graphics_pipeline == nullptr) {

--- a/src/vulkan_ice.hpp
+++ b/src/vulkan_ice.hpp
@@ -95,8 +95,10 @@ private:
   // utility functions
   bool is_validation_supported();
   void pick_physical_device();
-  bool check_device_extension_support(const vk::PhysicalDevice &device);
-  bool is_device_suitable(const vk::PhysicalDevice &device);
+  bool
+  check_device_extension_support(const vk::PhysicalDevice &physical_device);
+  bool is_device_suitable(const vk::PhysicalDevice &physical_device);
+  vk::SampleCountFlagBits get_max_sample_count(); // for MSAA support
 
   // useful data
   QueueFamilyIndices indices;
@@ -145,6 +147,7 @@ private:
   std::vector<SwapChainFrame> swapchain_frames;
   vk::Format swapchain_format;
   vk::Extent2D swapchain_extent;
+  vk::SampleCountFlagBits msaa_samples{vk::SampleCountFlagBits::e1};
   vk::Queue graphics_queue{nullptr}, present_queue{nullptr};
   vk::PhysicalDevice physical_device{nullptr};
   vk::Device device{nullptr};


### PR DESCRIPTION
## Added Multisampling support. 
(multisampling is capped at 8 bit for better performance)

### Edits

`ice_image`

* make_image - Added number of samples as an argument for image creation. It is used in ImageCreateInfo struct's samples field. A suitable default of vk::SampleCountFlagBits::e1 was set to prevent errors in other places (Like textures, Engine code etc)
* ImageCreationInput struct - added msaa_samples.

`swapchain`
*  SwapChainFrame struct - changed it to a struct since it i added msaa_samples member variable to swapchain frame, declare the trifecta of image resources for color (image, image view and memory). This would be used by our framebuffer for the multisampled color image.
*  SwapchainFrame make depth resources - in the create image,  passed in the msaa samples for the make_image function for the depth resources. 
*  SwapchainFrame make color resources - initialized color image resources (image, image view and memory).  Used the msaa_samples to the make image for the color resources as well as adding a usage bit of vk::ImageUsageFlagBits::eTransientAttachment to indicate that this image will be short lived (less than a frame). Specified only one mip level since it is used by framebuffer and is not a texture resource. 
*  delete the new color resources in the frame::destroy() method.

`Framebuffer`
* make_framebuffer - used multisampled color buffer view as the image view for SKY framebuffer. Used multisampled color buffer view, depth buffer view and then swapchain image view for the STANDARD framebuffer.

`pipeline`
*  GraphicsPipelinBundle struct- Added msaa_samples field and changed swapchain image format from a vector to a single value
*  make renderpass - removed.
*  make sky renderpass - make renderpass was changed to this specialized function. There is a single color attachment and it is the multisampled image. The function signatures were also simplified.
*  make scene renderpass - first attachment is also the multisampled image and then the depth attachment. The last attachment is the swapchain image. This also acts as the resolve attachment. Made sure to use eClear for the loadOp for the depth attachment.
*  make graphics pipeline - set in the multisampling state create info.rasterizationSamples to msaa_samples and enable sampleShading and give a nominal min sample shading value. Added a ternary conditional to choose the renderpass to make based on if a depth format is present or not. This function is reused by both pipelines.


`VulkanIce`
*  is_device_suitable - made sure to pick a device that has support for sampler anisotropy. Finished previous TODO, checked for swapchain adequacy (format and present mode features are not empty). Used physical_device as argument name for more clarity.
*  make device - set the sampleRateShading in device_features to vk::True to boost framerate. Also enabled samplerAnisotropy.
*  Header - Added a new utility function get_max_sample_count() that gets the max sample count, this is useful in determining the sample count that would be used for multisampling. Added add a class member variable, vk::sampleCountFlagBits msaa_samples, to store this value. 
*  get_max_sample_count() - Queried device to see how many samples it supports. The color buffer and the depth buffer can be multisampled with individually different sample counts. Used the highest count that can be supported by both of them. Got physical device properties, then masked out the limits.framebufferColorSampleCounts property of both the depth and color buffer to get one that works for both. Then this value is checked (ANDed) with all the sample count bits  to get one that is available. 
*  setup_swapchain - called get_max_sample_count() here and stored the msaa_samples capped at a value of 8 samples. This would be used in the entire program. Passed this msaa_samples value to the create_swapchain_bundle function to create frame images.
*  setup_pipeline_bundle - passed the msaa_samples value to the GraphicsPipelineBundle struct for both pipelines. modified swapchain image format fields to match new data type. Set loadOp of scene pipeline to eLoad and initial layout to eColorAttachmentOptimal
*  record_sky_draw_commands - removed clear values since they are not used.