### PR TITLE
Set Visual Studio working directory to TargetDir Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,9 @@ if(MSVC)
 
   # Needed in Visual Studio to enable file access to non-local paths
   # TargetDir is a VS macro containing path to executable directory 
-  set_target_properties(${vulkan_apps} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$(TargetDir)/" )
+  set_target_properties(
+    ${vulkan_apps} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:${vulkan_apps}>/" 
+  )
 
   # Copy compiled shaders to executable directory
   # Add post-build commands

--- a/src/data_buffers.hpp
+++ b/src/data_buffers.hpp
@@ -152,7 +152,7 @@ create_device_local_buffer(vk::PhysicalDevice physical_device,
                                   buffer_input.size, queue, command_buffer);
   if (result != vk::Result::eSuccess) {
 #ifndef NDEBUG
-    std::cout << std::format("{} copy operation  creation failed!\n",
+    std::cerr << std::format("{} copy operation creation failed!\n",
                              vk::to_string(usage_bit));
 #endif
   }

--- a/src/descriptors.hpp
+++ b/src/descriptors.hpp
@@ -53,7 +53,7 @@ make_descriptor_set_layout(vk::Device device,
     return device.createDescriptorSetLayout(layout_info);
   } catch (vk::SystemError err) {
 #ifndef NDEBUG
-    std::cout << "Failed to create Descriptor Set Layout\n";
+    std::cerr << "Failed to create Descriptor Set Layout\n";
 #endif
     return nullptr;
   }
@@ -92,7 +92,7 @@ make_descriptor_pool(vk::Device device, uint32_t size,
   } catch (vk::SystemError err) {
 
 #ifndef NDEBUG
-    std::cout << "Failed to make descriptor pool\n";
+    std::cerr << "Failed to make descriptor pool\n";
 #endif
 
     return nullptr;
@@ -121,7 +121,7 @@ allocate_descriptor_sets(vk::Device device, vk::DescriptorPool descriptor_pool,
     return device.allocateDescriptorSets(allocation_info)[0];
   } catch (vk::SystemError err) {
 #ifndef NDEBUG
-    std::cout << "Failed to allocate descriptor set from pool\n";
+    std::cerr << "Failed to allocate descriptor set from pool\n";
 #endif
     return nullptr;
   }

--- a/src/framebuffer.hpp
+++ b/src/framebuffer.hpp
@@ -37,9 +37,13 @@ inline void make_framebuffers(const FramebufferInput &input_bundle,
         input_bundle.device.createFramebuffer(framebuffer_info);
 
     if (out_frames[i].framebuffer[PipelineType::SKY] == nullptr) {
-      std::cout << std::format("Failed to create Sky framebuffer for frame {}",
+#ifndef NDEBUG
+      std::cerr << std::format("Failed to create Sky framebuffer for frame {}",
                                i)
                 << std::endl;
+#endif
+      throw std::runtime_error(
+          std::format("Failed to create Sky framebuffer for frame {}", i));
     }
 
     // Standard Pipeline
@@ -55,9 +59,13 @@ inline void make_framebuffers(const FramebufferInput &input_bundle,
         input_bundle.device.createFramebuffer(framebuffer_info);
 
     if (out_frames[i].framebuffer[PipelineType::STANDARD] == nullptr) {
-      std::cout << std::format(
+#ifndef NDEBUG
+      std::cerr << std::format(
                        "Failed to create standard framebuffer for frame {}", i)
                 << std::endl;
+#endif
+      throw std::runtime_error(
+          std::format("Failed to create standard framebuffer for frame {}", i));
     }
 
     // imgui framebuffer
@@ -70,9 +78,13 @@ inline void make_framebuffers(const FramebufferInput &input_bundle,
         input_bundle.device.createFramebuffer(framebuffer_info);
 
     if (out_frames[i].imgui_framebuffer == nullptr) {
-      std::cout << std::format(
+#ifndef NDEBUG
+      std::cerr << std::format(
                        "Failed to create ImGui framebuffer for frame {}", i)
                 << std::endl;
+#endif
+      throw std::runtime_error(
+          std::format("Failed to create ImGui framebuffer for frame {}", i));
     }
   }
 }

--- a/src/images/ice_cube_map.cpp
+++ b/src/images/ice_cube_map.cpp
@@ -184,7 +184,9 @@ void CubeMap::make_sampler() {
   try {
     sampler = logical_device.createSampler(sampler_info);
   } catch (vk::SystemError err) {
+#ifndef NDEBUG
     std::cout << "Failed to make sampler for Cube Map." << std::endl;
+#endif
   }
 #ifndef NDEBUG
   std::cout << "Finished Creating the sampler for Cube Map\n\n" << std::endl;

--- a/src/images/ice_texture.cpp
+++ b/src/images/ice_texture.cpp
@@ -113,9 +113,11 @@ void Texture::load() {
 #endif
   pixels = stbi_load(filename, &width, &height, &channels, STBI_rgb_alpha);
   if (pixels == nullptr) {
+#ifndef NDEBUG
     std::cout << std::format("Unable to load: {}, reason: {}", filename,
                              stbi_failure_reason())
               << std::endl;
+#endif
     width = height = 10;
     channels = 4;
 #ifndef NDEBUG

--- a/src/loaders.hpp
+++ b/src/loaders.hpp
@@ -14,7 +14,9 @@ inline std::vector<char> read_file(const std::string &filename) {
                          std::ios::binary); // start reading at the end of file.
 
   if (!file.is_open()) {
+#ifndef NDEBUG
     std::cerr << "Failed to open file" << std::endl;
+#endif
     throw std::runtime_error("failed to open file!");
   }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -396,9 +396,11 @@ void GltfMesh::bind_mesh(tinygltf::Mesh &mesh,
           indices.push_back(index_data_int[i]);
         }
       } else {
+#ifndef NDEBUG
         std::cerr
             << "Warning: Unsupported index component type. Skipping indices."
             << std::endl;
+#endif
       }
     } else {
       // If no indices are provided, create a simple index buffer

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -429,7 +429,10 @@ make_graphics_pipeline(const GraphicsPipelineInBundle &specification) {
   vk::Pipeline graphics_pipeline =
       specification.device.createGraphicsPipeline(nullptr, pipeline_info).value;
   if (graphics_pipeline == nullptr) {
+#ifndef NDEBUG
     std::cerr << "Failed to create Pipeline" << std::endl;
+#endif
+    throw std::runtime_error("Failed to create Pipeline");
   }
 
   GraphicsPipelineOutBundle output{.layout = pipeline_layout,

--- a/src/swapchain.hpp
+++ b/src/swapchain.hpp
@@ -222,8 +222,10 @@ inline SwapChainBundle create_swapchain_bundle(
   try {
     bundle.swapchain = logical_device.createSwapchainKHR(swap_info);
   } catch (const vk::SystemError &e) {
-    throw std::runtime_error("failed to create swapchain");
+#ifndef NDEBUG
     std::cerr << e.what() << '\n';
+#endif
+    throw std::runtime_error("failed to create swapchain");
   }
 
   std::vector<vk::Image> images =


### PR DESCRIPTION
Used generator expressions in `cmake` to ensure that the macros are evaluated immediately and not when it is built or executed. The former is only executed by `cmake `during the BUILD stage.

Then
Protected debug logs with ifdefs in more files