### PR TITLE
Increase Pipeline configurability

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -3,7 +3,6 @@
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 
-
 namespace ice {
 
 Camera::Camera(CameraDimensions dim, glm::vec3 position)

--- a/src/data_buffers.hpp
+++ b/src/data_buffers.hpp
@@ -135,7 +135,8 @@ inline BufferBundle create_device_local_buffer(
       .usage = vk::BufferUsageFlagBits::eTransferSrc,
       .logical_device = device,
       .physical_device = physical_device};
-  const ice::BufferBundle staging_buffer_bundle = ice::create_buffer(buffer_input);
+  const ice::BufferBundle staging_buffer_bundle =
+      ice::create_buffer(buffer_input);
 
   void *memory_location = device.mapMemory(staging_buffer_bundle.buffer_memory,
                                            0, buffer_input.size);
@@ -148,8 +149,9 @@ inline BufferBundle create_device_local_buffer(
   ice::BufferBundle buffer_bundle = create_buffer(buffer_input);
 
   // copy
-  const vk::Result result = copy_buffer(staging_buffer_bundle, buffer_bundle,
-                                  buffer_input.size, queue, command_buffer);
+  const vk::Result result =
+      copy_buffer(staging_buffer_bundle, buffer_bundle, buffer_input.size,
+                  queue, command_buffer);
   if (result != vk::Result::eSuccess) {
 #ifndef NDEBUG
     std::cerr << std::format("{} copy operation creation failed!\n",

--- a/src/first_app.cpp
+++ b/src/first_app.cpp
@@ -2,7 +2,6 @@
 
 #include "ice.hpp"
 
-
 int main() {
   ice::Ice block;
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -93,14 +93,14 @@ GraphicsPipelineBuilder& GraphicsPipelineBuilder::set_scissor(
 
 GraphicsPipelineBuilder& GraphicsPipelineBuilder::set_rasterization_state(
     vk::PolygonMode polygon_mode, vk::CullModeFlags cull_mode,
-    vk::FrontFace front_face) {
+    vk::FrontFace front_face, float line_width) {
   rasterization_state_.polygonMode = polygon_mode;
   rasterization_state_.cullMode = cull_mode;
   rasterization_state_.frontFace = front_face;
   rasterization_state_.depthClampEnable = vk::False;
   rasterization_state_.rasterizerDiscardEnable = vk::False;
   rasterization_state_.depthBiasEnable = vk::False;
-  rasterization_state_.lineWidth = 1.0f;
+  rasterization_state_.lineWidth = line_width;
 
   config_flags_ |= ConfigFlags::RASTERIZATION;
   return *this;

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -55,7 +55,8 @@ class GraphicsPipelineBuilder {
 
   GraphicsPipelineBuilder& set_rasterization_state(vk::PolygonMode polygon_mode,
                                                    vk::CullModeFlags cull_mode,
-                                                   vk::FrontFace front_face);
+                                                   vk::FrontFace front_face,
+                                                   float line_width = 1.0f);
 
   GraphicsPipelineBuilder& set_multisample_state(
       vk::SampleCountFlagBits samples);

--- a/src/ui_compatibility.hpp
+++ b/src/ui_compatibility.hpp
@@ -1,0 +1,85 @@
+#ifndef UI_COMPATIBILITY_HPP
+#define UI_COMPATIBILITY_HPP
+
+#include "vulkan_ice.hpp"
+
+namespace ui_compatibility {
+// Sets the MSAA samples for the given backend, returns the new sample count
+inline int set_msaa_samples(ice::VulkanIce& backend, int samples) {
+  vk::SampleCountFlagBits new_msaa_samples;
+  switch (samples) {
+    case 0:
+      new_msaa_samples = vk::SampleCountFlagBits::e1;
+#ifndef NDEBUG
+      std::cout << "Warning: Not ideal since we are resolving "
+                   "attachments regardless\n";
+#endif
+      break;
+    case 1:
+      new_msaa_samples = vk::SampleCountFlagBits::e2;
+      break;
+    case 2:
+      new_msaa_samples = vk::SampleCountFlagBits::e4;
+      break;
+    case 3:
+      new_msaa_samples = vk::SampleCountFlagBits::e8;
+      break;
+    case 4:
+      new_msaa_samples = vk::SampleCountFlagBits::e16;
+      break;
+    default:
+      new_msaa_samples = vk::SampleCountFlagBits::e8;
+      samples = 3;
+#ifndef NDEBUG
+      std::cout << "Warning: Invalid sample count selected. Defaulting to 8x."
+                << std::endl;
+#endif
+      break;
+  }
+
+  vk::SampleCountFlagBits max_msaa_samples = backend.get_max_sample_count();
+  if (new_msaa_samples > max_msaa_samples) {
+    new_msaa_samples = max_msaa_samples;
+    samples = 3;
+#ifndef NDEBUG
+    std::cout << std::format(
+        "Warning: Max supported sample count is {0}. Defaulting to "
+        "{0}.\n",
+        vk::to_string(max_msaa_samples));
+#endif
+  }
+  backend.set_msaa_samples(new_msaa_samples);
+  return samples;
+}
+
+// Sets the Culling Mode for given backend, returns the new culling mode value
+inline int set_cull_mode(ice::VulkanIce& backend, int cull_current) {
+  vk::CullModeFlagBits cull_mode;
+  switch (cull_current) {
+    case 0:
+      cull_mode = vk::CullModeFlagBits::eNone;
+      break;
+    case 1:
+      cull_mode = vk::CullModeFlagBits::eBack;
+      break;
+    case 2:
+      cull_mode = vk::CullModeFlagBits::eFront;
+      break;
+    case 3:
+      cull_mode = vk::CullModeFlagBits::eFrontAndBack;
+      break;
+    default:
+      cull_mode = vk::CullModeFlagBits::eBack;
+      cull_current = 2;
+#ifndef NDEBUG
+      std::cout << "Warning: Invalid cull mode selected. Defaulting to Back."
+                << std::endl;
+#endif
+      break;
+  }
+  backend.set_cull_mode(cull_mode);
+  return cull_current;
+}
+}  // namespace ui_compatibility
+
+#endif  // UI_COMPATIBILITY_HPP

--- a/src/vulkan_ice.hpp
+++ b/src/vulkan_ice.hpp
@@ -50,7 +50,7 @@ class VulkanIce {
   vk::DebugUtilsMessengerEXT debug_messenger{nullptr};
 #endif
 
-  explicit VulkanIce(IceWindow &window, bool render_points = false);
+  explicit VulkanIce(IceWindow &window);
   ~VulkanIce() noexcept;
 
   void render(Scene *scene);
@@ -60,8 +60,19 @@ class VulkanIce {
     return physical_device;
   }
 
-  bool render_points;
+  // UI settable states with setters
+  bool render_points = false;
+  bool render_wireframe = false;
+  bool show_skybox = true;
+  float line_width = 1.0f;
+  vk::CullModeFlagBits cull_mode = vk::CullModeFlagBits::eBack;
   void rebuild_pipelines();
+  void set_msaa_samples(vk::SampleCountFlagBits samples);
+  void set_cull_mode(vk::CullModeFlagBits mode);
+  void toggle_skybox(bool button);
+  void set_line_width(float width);
+
+  vk::SampleCountFlagBits get_max_sample_count();  // for MSAA support
 
  private:
   // instance setup
@@ -71,7 +82,7 @@ class VulkanIce {
   void make_device();
   void setup_pipeline_bundles();
   void setup_swapchain(vk::SwapchainKHR *old_swapchain = nullptr);
-  void recreate_swapchain();
+  void recreate_swapchain(bool recreate_pipelines = false);
 
   void setup_descriptor_set_layouts();
 
@@ -105,7 +116,6 @@ class VulkanIce {
   bool check_device_extension_support(
       const vk::PhysicalDevice &physical_device);
   bool is_device_suitable(const vk::PhysicalDevice &physical_device);
-  vk::SampleCountFlagBits get_max_sample_count();  // for MSAA support
 
   // useful data
   QueueFamilyIndices indices;


### PR DESCRIPTION
Increase Pipeline configurability
 - Configure MSAA samples count, LineWidth, CullingMode, Sky box visibility, render points, lines or wireframe
 - Added UI elements to configure pipeline
 - Added rebuild_pipelines() function to rebuild pipelines and manage resources
 - Modified recreate_swapchain() to conditionally build pipelines if necessary.
 - Add compatibility layer to translate UI commands to engine constructs.
 
 
 
![image](https://github.com/user-attachments/assets/3e9059e1-e7f0-4fec-bfd5-418e7bfa00ef)
